### PR TITLE
Removed 'binary' option from open() in `remove_footer`

### DIFF
--- a/HiyaCFW_Helper.py
+++ b/HiyaCFW_Helper.py
@@ -1094,7 +1094,7 @@ class Application(Frame):
             copyfile(self.nand_file.get(), file)
 
             # Back-up footer info
-            with open(self.console_id.get() + '-info.txt', 'wb') as f:
+            with open(self.console_id.get() + '-info.txt', 'w') as f:
                 f.write('eMMC CID: ' + self.cid.get() + '\r\n')
                 f.write('Console ID: ' + self.console_id.get() + '\r\n')
 


### PR DESCRIPTION
I've removed the 'binary' parameter since this can cause some trouble while writing CID and Con ID.

This was the error.
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "./HiyaCFW_Helper.py", line 1098, in remove_footer
    f.write('eMMC CID: ' + self.cid.get() + '\r\n')
TypeError: a bytes-like object is required, not 'str'
```

This at least fixed it for me...