### PR TITLE
Added Install Certificates.command in macOS requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Clicking on the integrated circuit button will give you a NAND mode, where you c
 * You will need to run the script as sudo in order to mount the decrypted NAND.
 
 ### _MacOS:_
-*  Python >3.5, you can install it with homebrew (install homebrew by running `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` in a terminal window, then `brew install python`).
+* Python >3.5, you can install it with homebrew (install homebrew by running `/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"` in a terminal window, then `brew install python`).
+* Go to `Applications` > `Python 3.<version>` and run `Install Certificates.command`. This will avoid the `"Could not get HiyaCFW"` error.
 
 ## What it includes:
 * 7za binaries for Windows, Linux and MacOS. It's used to decompress the HiyaCFW latest release as [@RocketRobz](https://github.com/RocketRobz) uploaded it as a 7z archive. Compiled from the [kornelski's GitHub repo](https://github.com/kornelski/7z).


### PR DESCRIPTION
Before running **Install Certificates.command** urllib.urlopen would throw this error:

`
<urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1056)>
`

Running the command solved it and might be helpful to other people with the same problem on macOS :)